### PR TITLE
add @vue/compiler-sfc to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "@vitejs/plugin-vue": "^1.2.1",
+    "@vue/compiler-sfc": "^3.0.10",
     "chokidar": "^3.5.1",
     "cross-env": "^7.0.3",
     "electron": "^12.0.2",


### PR DESCRIPTION
Fixed `Error: Cannot find module '@vue/compiler-sfc'` when run `yarn watch`.