### PR TITLE
chore(github): Ignore *.config.js and scripts/* for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.github/actions/**/*.js linguist-detectable=false
+scripts/*.js linguist-detectable=false
+*.config.js linguist-detectable=false


### PR DESCRIPTION
It makes `TypeScript` and `Vue` become top language.