### PR TITLE
Add vite/client to types in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "isolatedModules": true,
     "types": [
-      "node"
+      "node",
+      "vite/client".
     ],
     "typeRoots": [
       "node_modules/@types",


### PR DESCRIPTION
I experienced the issue described here https://github.com/vitejs/vite/issues/4002 with import.meta.env typing (except without vite/client in types as in this repo) . Adding this fixed the issue.