### PR TITLE
Flush ./dist on compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "precompile": "cross-env MODE=production npm run build",
-    "compile": "electron-builder build --config electron-builder.config.js --dir --config.asar=false",
+    "compile": "rimraf dist/ && electron-builder build --config electron-builder.config.js --dir --config.asar=false",
     "pretest": "npm run build",
     "test": "node tests/app.spec.js",
     "watch": "node scripts/watch.js",
@@ -41,6 +41,7 @@
     "eslint-plugin-vue": "7.18.0",
     "lint-staged": "11.1.2",
     "playwright": "1.14.1",
+    "rimraf": "^3.0.2",
     "simple-git-hooks": "2.6.1",
     "typescript": "4.4.2",
     "vite": "2.5.8",


### PR DESCRIPTION
Running `npm run compile` multiple times results in error:

```
  
⨯ unlinkat [project root]/dist/linux-unpacked/locales: directory not empty
github.com/develar/go-fs-util.EnsureEmptyDir
/Volumes/data/go/pkg/mod/github.com/develar/go-fs-util@v0.0.0-20190620175131-69a2d4542206/fs.go:98
github.com/develar/app-builder/pkg/electron.UnpackElectron.func1.1
/Volumes/data/Documents/app-builder/pkg/electron/electronUnpack.go:38
github.com/develar/app-builder/pkg/util.MapAsyncConcurrency.func2
/Volumes/data/Documents/app-builder/pkg/util/async.go:68
runtime.goexit
/usr/local/Cellar/go/1.16/libexec/src/runtime/asm_amd64.s:1371  
  ⨯ [project root]/node_modules/app-builder-bin/linux/x64/app-builder exited with code ERR_ELECTRON_BUILDER_CANNOT_EXECUTE  failedTask=build stackTrace=Error: [project root]/node_modules/app-builder-bin/linux/x64/app-builder exited with code ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
at ChildProcess.<anonymous> ([project root]/node_modules/builder-util/src/util.ts:249:14)
at Object.onceWrapper (events.js:422:26)
at ChildProcess.emit (events.js:315:20)
at maybeClose (internal/child_process.js:1048:16)
at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)
```

There's other package options like `del-cli` that boast some [nicer features](https://github.com/sindresorhus/del-cli/issues/26#issuecomment-882052144) so you might want to take this choice with a grain of salt