### PR TITLE
fix: add qoutes to `build:preload:types` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build:main && npm run build:preload && npm run build:renderer",
     "build:main": "cd ./packages/main && vite build",
     "build:preload": "cd ./packages/preload && vite build",
-    "build:preload:types": "dts-cb -i packages/preload/src/**/*.ts -o packages/preload/exposedInMainWorld.d.ts",
+    "build:preload:types": "dts-cb -i 'packages/preload/src/**/*.ts' -o 'packages/preload/exposedInMainWorld.d.ts'",
     "build:renderer": "cd ./packages/renderer && vite build",
     "compile": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.js --dir --config.asar=false",
     "test": "npm run test:main && npm run test:preload && npm run test:renderer && npm run test:e2e",


### PR DESCRIPTION
When I add more files to preload directory, need to make changes like this to make it work.