### PR TITLE
fix: eslint nested quotes and unused vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,39 +15,26 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": [
-    "@typescript-eslint"
-  ],
-  "ignorePatterns": [
-    "node_modules/**",
-    "**/dist/**"
-  ],
+  "plugins": ["@typescript-eslint"],
+  "ignorePatterns": ["node_modules/**", "**/dist/**"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/consistent-type-imports": "error",
 
-  /**
-   * Having a semicolon helps the optimizer interpret your code correctly.
-   * This avoids rare errors in optimized code.
-   * @see https://twitter.com/alex_kozack/status/1364210394328408066
-   */
-    "semi": [
-      "error",
-      "always"
-    ],
+    /**
+     * Having a semicolon helps the optimizer interpret your code correctly.
+     * This avoids rare errors in optimized code.
+     * @see https://twitter.com/alex_kozack/status/1364210394328408066
+     */
+    "semi": ["error", "always"],
     /**
      * This will make the history of changes in the hit a little cleaner
      */
-    "comma-dangle": [
-      "warn",
-      "always-multiline"
-    ],
+    "comma-dangle": ["warn", "always-multiline"],
     /**
      * Just for beauty
      */
-    "quotes": [
-      "warn", "single"
-    ]
+    "quotes": ["warn", "single"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,13 @@
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": ["node_modules/**", "**/dist/**"],
   "rules": {
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/consistent-type-imports": "error",
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,6 @@
     /**
      * Just for beauty
      */
-    "quotes": ["warn", "single"]
+    "quotes": ["warn", "single", { "avoidEscape": true }]
   }
 }


### PR DESCRIPTION
Reformat and fix splitted. Allow unused vars starting with underscore is mainly for positional params of API functions.