### PR TITLE
fix: :wrench: replace brotliSize

### DIFF
--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -34,7 +34,7 @@ const config = {
       },
     },
     emptyOutDir: true,
-    brotliSize: false,
+    reportCompressedSize: false,
   },
 };
 

--- a/packages/preload/vite.config.js
+++ b/packages/preload/vite.config.js
@@ -28,7 +28,7 @@ const config = {
       },
     },
     emptyOutDir: true,
-    brotliSize: false,
+    reportCompressedSize: false,
   },
   plugins: [
     preload.vite(),

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -34,7 +34,7 @@ const config = {
       input: join(PACKAGE_ROOT, 'index.html'),
     },
     emptyOutDir: true,
-    brotliSize: false,
+    reportCompressedSize: false,
   },
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
Afaik, brotliSize was deprecated. @see https://github.com/vitejs/vite/commit/f1b8b5fc9600e4c8607dbd572f5a9d7d8a588e78