### PR TITLE
refactor: :label: add explicit contextIsolation

### DIFF
--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -137,5 +137,8 @@ app.on('web-contents-created', (_, contents) => {
 
     // Disable Node.js integration
     webPreferences.nodeIntegration = false;
+
+    // Enable contextIsolation
+    webPreferences.contextIsolation = true;
   });
 });


### PR DESCRIPTION
Even though `contextIsolation` defaults to true, I personally feel like setting it explicitly would provide a more clear developer experience and expected behavior.