### PR TITLE
fix(types): Remove temp fix for MockedClass

### DIFF
--- a/packages/main/tests/unit.spec.ts
+++ b/packages/main/tests/unit.spec.ts
@@ -1,20 +1,8 @@
-import type {Constructable, Mocked, MockInstance} from 'vitest';
+import type {MockedClass} from 'vitest';
 import {beforeEach, expect, test, vi} from 'vitest';
 import {restoreOrCreateWindow} from '../src/mainWindow';
 
 import {BrowserWindow} from 'electron';
-
-/**
- * Manual fix of MockedClass type
- * See https://github.com/vitest-dev/vitest/issues/1730
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MockedClass<T extends Constructable> = MockInstance<T extends new (...args: infer P) => any ? P : never, InstanceType<T>> & {
-  prototype: T extends {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prototype: any;
-  } ? Mocked<T['prototype']> : never;
-} & T;
 
 /**
  * Mock real electron BrowserWindow API


### PR DESCRIPTION
The `MockedClass` type is fixed as of Vitest v0.20.0 [(Release Notes)](https://github.com/vitest-dev/vitest/releases/tag/v0.20.0)