### PR TITLE
fixed vue devtools not loading

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -50,11 +50,10 @@ app
 //     .whenReady()
 //     .then(() => import('electron-devtools-installer'))
 //     .then(module => {
-//       const {default: installExtension, VUEJS3_DEVTOOLS} =
-//         // @ts-expect-error Hotfix for https://github.com/cawa-93/vite-electron-builder/issues/915
+//       const {default: installExtension, VUEJS_DEVTOOLS} =
 //         typeof module.default === 'function' ? module : (module.default as typeof module);
 //
-//       return installExtension(VUEJS3_DEVTOOLS, {
+//       return installExtension(VUEJS_DEVTOOLS, {
 //         loadExtensionOptions: {
 //           allowFileAccess: true,
 //         },

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -51,6 +51,7 @@ app
 //     .then(() => import('electron-devtools-installer'))
 //     .then(module => {
 //       const {default: installExtension, VUEJS_DEVTOOLS} =
+//         //@ts-expect-error Hotfix for https://github.com/cawa-93/vite-electron-builder/issues/915
 //         typeof module.default === 'function' ? module : (module.default as typeof module);
 //
 //       return installExtension(VUEJS_DEVTOOLS, {


### PR DESCRIPTION
vuejs3_devtools plugin for chrome is deprecated and merged with the main vuejs_devtools plugin. This change reflects that and fixes the issue