### PR TITLE
Change `moduleResolution` to `nodenext`

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,6 +1,6 @@
 import {app} from 'electron';
 import './security-restrictions';
-import {restoreOrCreateWindow} from '/@/mainWindow';
+import {restoreOrCreateWindow} from '/@/mainWindow.js';
 import {platform} from 'node:process';
 import updater from 'electron-updater';
 

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "module": "esnext",
-    "target": "esnext",
+    "module": "NodeNext",
+    "target": "ESNext",
     "sourceMap": false,
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "skipLibCheck": true,
     "strict": true,
     "isolatedModules": true,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2,6 +2,6 @@
  * @module preload
  */
 
-import {sha256sum} from './nodeCrypto';
-import {versions} from './versions';
+import {sha256sum} from './nodeCrypto.js';
+import {versions} from './versions.js';
 export {sha256sum, versions};

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "module": "esnext",
-    "target": "esnext",
+    "module": "NodeNext",
+    "target": "ESNext",
     "sourceMap": false,
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "skipLibCheck": true,
     "strict": true,
     "isolatedModules": true,

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
+    "module": "ESNext",
+    "target": "ESNext",
     "sourceMap": false,
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "skipLibCheck": true,
     "strict": true,
     "isolatedModules": true,


### PR DESCRIPTION
According to the [TypeScript documentation](https://www.typescriptlang.org/tsconfig/#moduleResolution), the `moduleResolution` should be set to either `NodeNext`, `Node16`, or `Bundler` to fully support ESM-style imports in NodeJS. I have changed the the `.tsconfig`s accordingly. However, this changes seems to require to add `.js` to all imports of local files. I find this ugly and would be happy if somebody knows a way to not add the `.js` extensions for every local import.

I am also not sure about the casing for the module resolution strategy - followed the suggestions by my IDE. Feel free to change them to lower case.

This pull requests may resolve #997.