### PR TITLE
chore: renamed variable name

### DIFF
--- a/electron-builder.mjs
+++ b/electron-builder.mjs
@@ -94,7 +94,7 @@ async function getListOfFilesFromEachWorkspace() {
     pkg,
   });
 
-  const allFilesToExclude = [];
+  const allFilesToInclude = [];
 
   for (const [name, path] of workspaces) {
     const pkgPath = join(path, 'package.json');
@@ -103,8 +103,8 @@ async function getListOfFilesFromEachWorkspace() {
     let patterns = workspacePkg.files || ['dist/**', 'package.json'];
 
     patterns = patterns.map(p => join('node_modules', name, p));
-    allFilesToExclude.push(...patterns);
+    allFilesToInclude.push(...patterns);
   }
 
-  return allFilesToExclude;
+  return allFilesToInclude;
 }


### PR DESCRIPTION
Hello, I renamed the variable `allFilesToExclude` to `allFilesToInclude` because I thought it would be the more correct name.

Thanks.