### PR TITLE
Reorder of `exports` in `package.json`

### DIFF
--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -7,8 +7,8 @@
   },
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
     }
   },
   "dependencies": {

--- a/packages/preload/package.json
+++ b/packages/preload/package.json
@@ -7,12 +7,12 @@
   },
   "exports": {
     ".": {
-      "default": "./dist/_virtual_browser.mjs",
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "default": "./dist/_virtual_browser.mjs"
     },
     "./exposed.mjs": {
-      "default": "./dist/exposed.mjs",
-      "types": "./src/exposed.d.ts"
+      "types": "./src/exposed.d.ts",
+      "default": "./dist/exposed.mjs"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
After a clean setup of the template, users encounter this error:
![image](https://github.com/user-attachments/assets/fe7f67dc-2c0a-4a66-9f96-49cf6c04ad2a)

This change resolves the issue and ensures correct module resolution.

**Why this issue occurs:**
In package.json, fields like `default` and `types` are part of the module resolution process. Their order is crucial because JavaScript environments and bundlers (like ESBuild) evaluate these fields sequentially. Once a match is found, subsequent fields are ignored.

If `default` appears before `types`, the `types` condition is never evaluated, triggering the warning. Reordering those fields ensures `types` are prioritized correctly, allowing TypeScript tools to function as expected.