### PR TITLE
Fix: update launch configuration to point to dev-mode.js

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "Debug Main Process",
       "skipFiles": ["<node_internals>/**"],
-      "program": "${workspaceFolder}\\scripts\\watch.js",
+      "program": "${workspaceFolder}/packages/dev-mode.js",
       "autoAttachChildProcesses": true
     }
   ]


### PR DESCRIPTION
This PR fixes the `launch.json` debugger configuration to use packages/dev-mode.js to start the debugger, as seen in the npm start command and discussed in #1139.