### PR TITLE
Disable qwik and qwik-ts in CI configuration

### DIFF
--- a/.github/workflows/boilerplate-ci-entry.yml
+++ b/.github/workflows/boilerplate-ci-entry.yml
@@ -57,8 +57,8 @@ jobs:
           - svelte-ts
           - solid
           - solid-ts
-          - qwik
-          - qwik-ts
+          # - qwik
+          # - qwik-ts
 
 
   dependabot:


### PR DESCRIPTION
Comment out qwik and qwik-ts in CI workflow because it's broken againe.